### PR TITLE
修复日历最后一排显示错位的问题

### DIFF
--- a/src/app/(main)/schedule/calendar-render.tsx
+++ b/src/app/(main)/schedule/calendar-render.tsx
@@ -23,6 +23,7 @@ const generateDateInfo = async (year: number, month: number) => {
       })
     })
   }
+  for(let i = preDays + dateNum; i < 35; i++) dateInfo.push({ day: i%7})
   const result: IDateInfo[][] = []
   let week: IDateInfo[] = []
   for (const info of dateInfo) {

--- a/src/app/(main)/schedule/calendar-render.tsx
+++ b/src/app/(main)/schedule/calendar-render.tsx
@@ -23,7 +23,7 @@ const generateDateInfo = async (year: number, month: number) => {
       })
     })
   }
-  for(let i = preDays + dateNum; i < 35; i++) dateInfo.push({ day: i%7})
+  for (let i = preDays + dateNum; i < 35; i++) dateInfo.push({ day: i % 7 })
   const result: IDateInfo[][] = []
   let week: IDateInfo[] = []
   for (const info of dateInfo) {


### PR DESCRIPTION
由于gap-1挤压了按1/7比例分配的宽度，导致前几排的元素实际宽度是小于比例分配宽度的，总共偏移了24px的宽度

![屏幕截图 2024-11-09 211235](https://github.com/user-attachments/assets/a920153f-4490-4884-ad27-4614f872b82c)

修复

![屏幕截图 2024-11-09 213944](https://github.com/user-attachments/assets/2ea28af6-778b-4cf1-b21b-336036f6474d)
