### PR TITLE
修复：窄屏导航栏遗留了上边距导致的视觉问题，窄屏空日程栏提示文字重叠的问题

### DIFF
--- a/src/app/(main)/md-nav.tsx
+++ b/src/app/(main)/md-nav.tsx
@@ -39,7 +39,7 @@ const MdNav = () => {
       </div>
 
       <div
-        className={`h-[100vh] absolute w-full z-50 bg-black/50 my-2 dark:bg-black/70 ${open ? '' : 'hidden'}`}
+        className={`h-[100vh] absolute w-full z-50 bg-black/50 dark:bg-black/70 ${open ? '' : 'hidden'}`}
         onClick={menuSwitcher}
       />
       <ul

--- a/src/app/(main)/schedule/@detail/[day]/schedules.tsx
+++ b/src/app/(main)/schedule/@detail/[day]/schedules.tsx
@@ -18,9 +18,9 @@ const Schedules: React.FC<SchedulesProps> = async ({ year, month, day }) => {
         日程：{year} 年 {month} 月 {day} 日
       </h2>
       {schedules.length === 0 ? (
-        <p className='text-center text-lg my-auto italic text-gray-400 dark:text-gray-600'>
-          当前日期暂无日程
-        </p>
+        <div className='flex text-center text-lg my-auto h-full items-center justify-center italic text-gray-400 dark:text-gray-600'>
+          <p>当前日期暂无日程</p>
+        </div>
       ) : (
         <ul className='flex mt-8 items-center w-full h-full flex-col gap-2'>
           {schedules.map(p => {

--- a/src/app/(main)/schedule/@detail/[day]/schedules.tsx
+++ b/src/app/(main)/schedule/@detail/[day]/schedules.tsx
@@ -17,45 +17,46 @@ const Schedules: React.FC<SchedulesProps> = async ({ year, month, day }) => {
       <h2 className='text-2xl font-bold text-center'>
         日程：{year} 年 {month} 月 {day} 日
       </h2>
-      <ul className='flex mt-8 items-center w-full h-full flex-col gap-2'>
-        {schedules.length === 0 && (
-          <p className='text-center text-lg my-auto -translate-y-20 italic text-gray-400 dark:text-gray-600'>
-            当前日期暂无日程
-          </p>
-        )}
-        {schedules.map(p => {
-          const pushed =
-            new Date(p.publishDate).getTime() <= new Date().getTime()
-          return (
-            <div
-              key={p.id}
-              className='text-base py-3 px-4 rounded-lg relative w-full space-y-1'
-              style={{
-                backgroundColor: getHashColorByTeamName(p.team)
-              }}
-            >
-              <p>
-                {p.isFrontPage && (
-                  <span className='dark:bg-yellow-600/50 bg-yellow-400 rounded-md text-base px-1 py-0.5 mr-1'>
-                    头版
+      {schedules.length === 0 ? (
+        <p className='text-center text-lg my-auto italic text-gray-400 dark:text-gray-600'>
+          当前日期暂无日程
+        </p>
+      ) : (
+        <ul className='flex mt-8 items-center w-full h-full flex-col gap-2'>
+          {schedules.map(p => {
+            const pushed =
+              new Date(p.publishDate).getTime() <= new Date().getTime()
+            return (
+              <div
+                key={p.id}
+                className='text-base py-3 px-4 rounded-lg relative w-full space-y-1'
+                style={{
+                  backgroundColor: getHashColorByTeamName(p.team)
+                }}
+              >
+                <p>
+                  {p.isFrontPage && (
+                    <span className='dark:bg-yellow-600/50 bg-yellow-400 rounded-md text-base px-1 py-0.5 mr-1'>
+                      头版
+                    </span>
+                  )}
+                  <span className={!pushed ? '' : ' line-through'}>
+                    {p.title}
                   </span>
+                </p>
+                <p className='dark:bg-black/30 bg-white/35 w-fit py-0.5 px-1 rounded-lg text-sm'>
+                  {p.team}
+                </p>
+                {pushed && (
+                  <div className='absolute right-4 top-2'>
+                    <FaCheckCircle className='text-green-700 text-lg' />
+                  </div>
                 )}
-                <span className={!pushed ? '' : ' line-through'}>
-                  {p.title}
-                </span>
-              </p>
-              <p className='dark:bg-black/30 bg-white/35 w-fit py-0.5 px-1 rounded-lg text-sm'>
-                {p.team}
-              </p>
-              {pushed && (
-                <div className='absolute right-4 top-2'>
-                  <FaCheckCircle className='text-green-700 text-lg' />
-                </div>
-              )}
-            </div>
-          )
-        })}
-      </ul>
+              </div>
+            )
+          })}
+        </ul>)
+      }
     </div>
   )
 }

--- a/src/app/(main)/schedule/@detail/[day]/schedules.tsx
+++ b/src/app/(main)/schedule/@detail/[day]/schedules.tsx
@@ -55,8 +55,8 @@ const Schedules: React.FC<SchedulesProps> = async ({ year, month, day }) => {
               </div>
             )
           })}
-        </ul>)
-      }
+        </ul>
+      )}
     </div>
   )
 }

--- a/src/app/(main)/schedule/layout.tsx
+++ b/src/app/(main)/schedule/layout.tsx
@@ -10,7 +10,7 @@ const Layout = async ({
       <div className='flex flex-col aspect-video mx-auto dark:border-white/10 border-2 rounded-md p-2'>
         {children}
       </div>
-      <div className='flex flex-col mx-auto'>{detail}</div>
+      <div className='flex flex-col aspect-video mx-auto'>{detail}</div>
     </div>
   )
 }

--- a/src/app/(main)/schedule/layout.tsx
+++ b/src/app/(main)/schedule/layout.tsx
@@ -10,7 +10,7 @@ const Layout = async ({
       <div className='flex flex-col aspect-video mx-auto dark:border-white/10 border-2 rounded-md p-2'>
         {children}
       </div>
-      <div className='flex flex-col aspect-video mx-auto'>{detail}</div>
+      <div className='flex flex-col mx-auto'>{detail}</div>
     </div>
   )
 }


### PR DESCRIPTION
## 修复前

![image](https://github.com/user-attachments/assets/efa895fe-3d62-4d5b-bf1d-1d27aef15636)

![image](https://github.com/user-attachments/assets/9dbda01b-cb5c-4355-a308-fec826090668)

## 修复后

![屏幕截图 2024-11-10 095730](https://github.com/user-attachments/assets/5295921e-35ef-42cb-b404-20857eb74752)

![屏幕截图 2024-11-10 095748](https://github.com/user-attachments/assets/c1250ac8-4b97-4e0e-a843-7888fc4c774a)
